### PR TITLE
add do_HEAD to fix status checks

### DIFF
--- a/ollama_proxy_server/main.py
+++ b/ollama_proxy_server/main.py
@@ -87,6 +87,10 @@ def main():
             except BrokenPipeError:
                 pass
 
+        def do_HEAD(self):
+            self.log_request()
+            self.proxy()
+
         def do_GET(self):
             self.log_request()
             self.proxy()


### PR DESCRIPTION
Some apps (enchanted LLM for example) like to check `/` with HEAD to track status.