### PR TITLE
Fix Chunked Response Formatting

### DIFF
--- a/ollama_proxy_server/main.py
+++ b/ollama_proxy_server/main.py
@@ -75,15 +75,13 @@ def main():
             for key, value in response.headers.items():
                 if key.lower() not in ['content-length', 'transfer-encoding', 'content-encoding']:
                     self.send_header(key, value)
-            self.send_header('Transfer-Encoding', 'chunked')
             self.end_headers()
-
+        
             try:
-                for chunk in response.iter_content(chunk_size=1024):
-                    if chunk:
-                        self.wfile.write(b"%X\r\n%s\r\n" % (len(chunk), chunk))
-                        self.wfile.flush()
-                self.wfile.write(b"0\r\n\r\n")
+                # Read the full content to avoid chunking issues
+                content = response.content
+                self.wfile.write(content)
+                self.wfile.flush()
             except BrokenPipeError:
                 pass
 

--- a/ollama_proxy_server/main.py
+++ b/ollama_proxy_server/main.py
@@ -85,6 +85,7 @@ def main():
             except BrokenPipeError:
                 pass
 
+
         def do_HEAD(self):
             self.log_request()
             self.proxy()
@@ -152,7 +153,7 @@ def main():
                     min_queued_server = server
 
             # Apply the queuing mechanism only for a specific endpoint.
-            if path == '/api/generate' or path == '/api/chat':
+            if path == '/api/generate' or path == '/api/chat' or path == '/v1/chat/completions':
                 que = min_queued_server[1]['queue']
                 client_ip, client_port = self.client_address
                 self.add_access_log_entry(event="gen_request", user=self.user, ip_address=client_ip, access="Authorized", server=min_queued_server[0], nb_queued_requests_on_server=que.qsize())

--- a/ollama_proxy_server/main.py
+++ b/ollama_proxy_server/main.py
@@ -76,7 +76,7 @@ def main():
                 if key.lower() not in ['content-length', 'transfer-encoding', 'content-encoding']:
                     self.send_header(key, value)
             self.end_headers()
-        
+
             try:
                 # Read the full content to avoid chunking issues
                 content = response.content
@@ -84,7 +84,6 @@ def main():
                 self.wfile.flush()
             except BrokenPipeError:
                 pass
-
 
         def do_HEAD(self):
             self.log_request()


### PR DESCRIPTION
Hey folks,

I'm new to this repo and wasn't sure how the original `_send_response` method was supposed to work, but I noticed it was adding  a "400" at the beginning and a "0" at the end of JSON responses. I tweaked it to properly handle response content without extra characters. Tested it, and it seems to work fine now!

I also added the `/v1/chat/completions` to the endpoints considered by the queuing mechanism. This endpoint is accessed when running ollama with OpenAI's API.

Let me know if anything needs adjusting. Happy to contribute! 