### PR TITLE
fixing ollama server timeout

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -34,6 +34,15 @@ class Settings(BaseSettings):
     RATE_LIMIT_REQUESTS: int = 100
     RATE_LIMIT_WINDOW_MINUTES: int = 1
 
+    # --- HTTP Client (Backend) Timeouts & Limits ---
+    HTTPX_CONNECT_TIMEOUT: float = 10.0
+    HTTPX_READ_TIMEOUT: float = 600.0
+    HTTPX_WRITE_TIMEOUT: float = 600.0
+    HTTPX_POOL_TIMEOUT: float = 60.0
+    HTTPX_MAX_KEEPALIVE_CONNECTIONS: int = 20
+    HTTPX_MAX_CONNECTIONS: int = 100
+    HTTPX_KEEPALIVE_EXPIRY: float = 60.0
+
     # --- IP Access Control ---
     ALLOWED_IPS: List[str] = []
     DENIED_IPS: List[str] = []

--- a/app/main.py
+++ b/app/main.py
@@ -88,7 +88,19 @@ async def lifespan(app: FastAPI):
     await create_initial_admin_user()
     await create_initial_servers()
 
-    app.state.http_client = httpx.AsyncClient()
+    # Configure HTTP client using settings
+    timeout = httpx.Timeout(
+        connect=settings.HTTPX_CONNECT_TIMEOUT,
+        read=settings.HTTPX_READ_TIMEOUT,
+        write=settings.HTTPX_WRITE_TIMEOUT,
+        pool=settings.HTTPX_POOL_TIMEOUT,
+    )
+    limits = httpx.Limits(
+        max_keepalive_connections=settings.HTTPX_MAX_KEEPALIVE_CONNECTIONS,
+        max_connections=settings.HTTPX_MAX_CONNECTIONS,
+        keepalive_expiry=settings.HTTPX_KEEPALIVE_EXPIRY,
+    )
+    app.state.http_client = httpx.AsyncClient(timeout=timeout, limits=limits)
 
     try:
         app.state.redis = redis.from_url(str(settings.REDIS_URL), encoding="utf-8", decode_responses=True)


### PR DESCRIPTION
## Overview

We addressed intermittent 499/504 errors and “client connection closed before server finished loading” when proxying long-running Ollama model loads by increasing and externalizing HTTP client timeouts and connection pool limits.

### Symptoms
- Proxy returned: `{"detail":"Could not connect to backend server."}`
- Ollama logs showed aborted loads while models were still initializing.

### Root Cause
- The proxy’s default HTTP client timeouts were too short for first-time model loads or cold starts, causing the client to disconnect before Ollama finished preparing the model.

## Changes Made

### 1) Configurable HTTP client timeouts and limits
- Added new settings in `app/core/config.py` to tune the proxy’s `httpx.AsyncClient`:
  - `HTTPX_CONNECT_TIMEOUT` (default: 10.0)
  - `HTTPX_READ_TIMEOUT` (default: 600.0)
  - `HTTPX_WRITE_TIMEOUT` (default: 600.0)
  - `HTTPX_POOL_TIMEOUT` (default: 60.0)
  - `HTTPX_MAX_KEEPALIVE_CONNECTIONS` (default: 20)
  - `HTTPX_MAX_CONNECTIONS` (default: 100)
  - `HTTPX_KEEPALIVE_EXPIRY` (default: 60.0)

### 2) Apply those settings to the shared HTTP client
- Updated `app/main.py` to construct `httpx.AsyncClient` with the above `Timeout` and `Limits`. This prevents premature disconnects during long model warm-ups and improves concurrency under load.

## How to Configure

Add or adjust the following in your `.env` (values shown are defaults):

```env
# HTTP client timeouts (seconds)
HTTPX_CONNECT_TIMEOUT=10.0
HTTPX_READ_TIMEOUT=600.0
HTTPX_WRITE_TIMEOUT=600.0
HTTPX_POOL_TIMEOUT=60.0

# Connection pooling
HTTPX_MAX_KEEPALIVE_CONNECTIONS=20
HTTPX_MAX_CONNECTIONS=100
HTTPX_KEEPALIVE_EXPIRY=60.0
```

If your models need longer to load (e.g., large or first-time pulls), increase `HTTPX_READ_TIMEOUT` and `HTTPX_WRITE_TIMEOUT` (e.g., 1200).

## Deployment Notes

- Restart the proxy after updating `.env`.
- If using the foreground script, stop and re-run `run.sh`.
- If using systemd, run:
  - `sudo systemctl restart ollama_proxy.service`

## Validation Steps

1. Verify backend availability:
   - `GET /api/tags` should succeed.
2. Test generation with a model that requires a warm-up:
   - Call `POST /api/generate` through the proxy and confirm the request stays open until the model is ready and begins streaming.
3. If the Ollama backend still logs “timed out waiting for llama runner to start,” increase `HTTPX_READ_TIMEOUT` and warm the model by invoking it directly once on the backend.

## Related Issues

- Error: client connection closed before server finished loading, aborting load ([Issue #36](https://github.com/ParisNeo/ollama_proxy_server/issues/36))
- “Could not connect to backend server.” on `/api/generate` ([Issue #34](https://github.com/ParisNeo/ollama_proxy_server/issues/34))