### PR TITLE
fix(docker): File permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ WORKDIR /home/app
 COPY ./app ./app
 COPY gunicorn_conf.py .
 
-RUN chmod 0755 -R ./app gunicorn_conf.py
+RUN chmod 0755 -R ./app gunicorn_conf.py && \
+    mkdir -p ./app/static/uploads ./.ssl ./benchmarks && \
+    chown app:app ./app/static/uploads ./.ssl ./benchmarks
 
 USER app
 


### PR DESCRIPTION
Running this Docker image in Kubernetes with an unprivileged user results in the following error:
```sh
PermissionError: [Errno 13] Permission denied: '/home/app/gunicorn_conf.py'
```
This is because the `app` user didn't have execute permissions for `gunicorn_conf.py`
```sh
ls -l
drwxr-xr-x 9 root root 4096 Feb 20 02:45 app
-rw-r----- 1 root root 2268 Feb 20 02:45 gunicorn_conf.py
```